### PR TITLE
fix 16: исправить ошибку в разделе Онбординг

### DIFF
--- a/src/bot/keyboards/onboarding_keyboards.py
+++ b/src/bot/keyboards/onboarding_keyboards.py
@@ -25,7 +25,7 @@ onboarding_markup = InlineKeyboardMarkup(onboarding_keyboard)
 mentor_keyboard = [
     [
         InlineKeyboardButton(
-            'Задачи Наставника/Бадди',
+            'Задачи Наставника/Бадди при онбординге',
             callback_data=f'{INFO_PREFIX}menor_tasks',
         )
     ],


### PR DESCRIPTION
Исправлена ошибка в названии кнопки в разделе "Онбординг"
Актуальное значение: «Задачи наставника/Бадди при онбординге»
Ссылка на задачу в notion:
https://www.notion.so/fix-16-278d154f33d3449f9263c4a57ac530f5?pvs=4 