### PR TITLE
feature 29: отправка сообщений по email(fix flake8)

### DIFF
--- a/src/bot/constants/schemas.py
+++ b/src/bot/constants/schemas.py
@@ -7,7 +7,8 @@ class QuestionModel(BaseModel):
     question: str
 
     @validator('question')
-    def check_question_length(cls, value):
+    def check_question_length(cls, value):  # noqa
+        '''Проверка на количество символов'''
         if not (3 <= len(value) <= 150):
             raise ValueError(
                 'Длина сообщения должна быть от 3 до 150 символов'
@@ -15,7 +16,8 @@ class QuestionModel(BaseModel):
         return value
 
     @validator('question')
-    def check_question_content(cls, value):
+    def check_question_content(cls, value):  # noqa
+        '''Проверка на кирилицу'''
         if not re.match(r'^[а-яА-Я0-9\s\W]*$', value):
             raise ValueError('Сообщение должно содержать только кириллицу.')
         return value


### PR DESCRIPTION
Ошибка flake8, которая появилась, указывает на использование неправильного названия для первого аргумента классовых методов, но в случае с Pydantic это не так. Весь Гугл перерыл) Классовые методы в Pydantic не используют self, поскольку они не относятся к конкретному экземпляру класса. Поэтому тут решил добавить комментарий # noqa, чтобы обойти ее.