### PR TITLE
fix/github actions tests fixes after previous merge (Feature31/search by keywords)

### DIFF
--- a/src/bot/core/db.py
+++ b/src/bot/core/db.py
@@ -6,9 +6,8 @@ from .settings import settings
 
 
 class PreBase:
-
     @declared_attr
-    def __tablename__(cls):
+    def __tablename__(cls):  # noqa
         return cls.__name__.lower()
 
     id = Column(Integer, primary_key=True)

--- a/src/bot/utils/keyword_search.py
+++ b/src/bot/utils/keyword_search.py
@@ -78,7 +78,7 @@ async def get_contacts_full_info(contacts: Contact) -> list:
     return result.all()
 
 
-async def find_contacts_in_DB(words: set) -> list:
+async def find_contacts_in_db(words: set) -> list:
     '''
     Поиск по ключевым словам.
     Поиск контактов в БД.
@@ -128,6 +128,6 @@ async def find_contacts(user_text: str) -> str:
     Поиск контактов по запросу пользователя.
     '''
     words = prepare_words(user_text)
-    contacts = await find_contacts_in_DB(words)
+    contacts = await find_contacts_in_db(words)
     contacts_full_info = await get_contacts_full_info(contacts)
     return generate_answer(contacts_full_info)

--- a/src/contacts_upload.py
+++ b/src/contacts_upload.py
@@ -846,7 +846,7 @@ async def upload_contacts():
 
 
 async def upload_departments():
-    '''Загрузка данных в таблицу отделос.'''
+    '''Загрузка данных в таблицу отделов.'''
     async with AsyncSessionLocal() as session:
         for department in DEPARTMENTS_RAW:
             new_department = Department()


### PR DESCRIPTION
После предыдущего мержда тесты github actions отработали с ошибками. Это фикс одной ошибки (в названии одного из методов DB было указано большими буквами, что не гуд) и добавление игнора для другой (там реально метод класса делается декоратором @declared_attr, а тест просил переделать в метод экземпляра класса, что неверно)

Ссылка на задачу в notion:

https://www.notion.so/feature-31-3bf10cc393b3488aa7b9afb1e7aa6585?pvs=4
